### PR TITLE
a.ivanov/33 Задача 33. Многопоточный HTTP прокси с пулом потоков

### DIFF
--- a/a.ivanov/33/make.sh
+++ b/a.ivanov/33/make.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd src
+./compile.sh
+cd ..
+

--- a/a.ivanov/33/src/cache/cache.h
+++ b/a.ivanov/33/src/cache/cache.h
@@ -1,0 +1,29 @@
+#ifndef HTTP_CPP_PROXY_CACHE_H
+#define HTTP_CPP_PROXY_CACHE_H
+
+#include <string>
+#include <functional>
+
+namespace aiwannafly {
+    template <class T>
+    class Cache {
+    public:
+        virtual ~Cache() = default;;
+
+        virtual T *get(const std::string&) = 0;
+
+        virtual void erase(const std::string&) = 0;
+
+        virtual bool contains(const std::string&) = 0;
+
+        virtual bool put(const std::string&, T *value) = 0;
+
+        virtual size_t size() = 0;
+
+        virtual size_t sizeBytes(std::function<size_t(const T*)> func) = 0;
+
+        virtual void clear() = 0;
+    };
+}
+
+#endif //HTTP_CPP_PROXY_CACHE_H

--- a/a.ivanov/33/src/cache/cache.h
+++ b/a.ivanov/33/src/cache/cache.h
@@ -7,7 +7,11 @@
 template<class T>
 class Cache {
 public:
-    virtual ~Cache() = default;;
+    virtual ~Cache() = default;
+
+    virtual void lock() = 0;
+
+    virtual void unlock() = 0;
 
     virtual T *get(const std::string &) = 0;
 

--- a/a.ivanov/33/src/cache/cache.h
+++ b/a.ivanov/33/src/cache/cache.h
@@ -4,26 +4,25 @@
 #include <string>
 #include <functional>
 
-namespace aiwannafly {
-    template <class T>
-    class Cache {
-    public:
-        virtual ~Cache() = default;;
+template<class T>
+class Cache {
+public:
+    virtual ~Cache() = default;;
 
-        virtual T *get(const std::string&) = 0;
+    virtual T *get(const std::string &) = 0;
 
-        virtual void erase(const std::string&) = 0;
+    virtual void erase(const std::string &) = 0;
 
-        virtual bool contains(const std::string&) = 0;
+    virtual bool contains(const std::string &) = 0;
 
-        virtual bool put(const std::string&, T *value) = 0;
+    virtual bool put(const std::string &, T *value) = 0;
 
-        virtual size_t size() = 0;
+    virtual size_t size() = 0;
 
-        virtual size_t sizeBytes(std::function<size_t(const T*)> func) = 0;
+    virtual size_t sizeBytes(std::function<size_t(const T *)> func) = 0;
 
-        virtual void clear() = 0;
-    };
-}
+    virtual void clear() = 0;
+};
+
 
 #endif //HTTP_CPP_PROXY_CACHE_H

--- a/a.ivanov/33/src/cache/map_cache.h
+++ b/a.ivanov/33/src/cache/map_cache.h
@@ -3,6 +3,7 @@
 
 #include <map>
 #include <cassert>
+#include <pthread.h>
 
 #include "cache.h"
 

--- a/a.ivanov/33/src/cache/map_cache.h
+++ b/a.ivanov/33/src/cache/map_cache.h
@@ -7,78 +7,79 @@
 
 #include "cache.h"
 
-namespace aiwannafly {
-    template <class T>
-    class MapCache final : public Cache<T> {
-    public:
+template<class T>
+class MapCache final : public Cache<T> {
+public:
 
-        MapCache() {
-            this->table = new std::map<std::string, T*>();
-            mutex = new pthread_mutex_t;
-            int code = pthread_mutex_init(mutex, nullptr);
-            assert(code == 0);
-        }
+    MapCache() {
+        this->table = new std::map<std::string, T *>();
+        rwlock = new pthread_rwlock_t;
+        int code = pthread_rwlock_init(rwlock, nullptr);
+        assert(code == 0);
+    }
 
-        ~MapCache() {
-            delete table;
-            pthread_mutex_destroy(mutex);
-            delete mutex;
-        }
+    ~MapCache() {
+        delete table;
+        pthread_rwlock_destroy(rwlock);
+        delete rwlock;
+    }
 
-        T *get(const std::string& key) override {
-            pthread_mutex_lock(mutex);
-            auto *res = table->at(key);
-            pthread_mutex_unlock(mutex);
-            return res;
-        }
+    T *get(const std::string &key) override {
+        pthread_rwlock_rdlock(rwlock);
+        auto *res = table->at(key);
+        pthread_rwlock_unlock(rwlock);
+        return res;
+    }
 
-        void erase(const std::string &key) override {
-            pthread_mutex_lock(mutex);
-            table->erase(key);
-            pthread_mutex_unlock(mutex);
-        }
+    void erase(const std::string &key) override {
+        pthread_rwlock_wrlock(rwlock);
+        table->erase(key);
+        pthread_rwlock_unlock(rwlock);
+    }
 
-        bool contains(const std::string &key) override {
-            pthread_mutex_lock(mutex);
-            bool res = table->contains(key);
-            pthread_mutex_unlock(mutex);
-            return res;
-        }
+    bool contains(const std::string &key) override {
+        pthread_rwlock_rdlock(rwlock);
+        bool res = table->contains(key);
+        pthread_rwlock_unlock(rwlock);
+        return res;
+    }
 
-        bool put(const std::string & key, T *value) override {
-            pthread_mutex_lock(mutex);
-            (*table)[key] = value;
-            pthread_mutex_unlock(mutex);
-            return true;
-        };
-
-        size_t size() override {
-            return table->size();
-        }
-
-        size_t sizeBytes(std::function<size_t(const T *)> size) override {
-            pthread_mutex_lock(mutex);
-            size_t total_size = 0;
-            for (auto it = table->begin(); it != table->end(); it++) {
-                total_size += size(it->second);
-            }
-            pthread_mutex_unlock(mutex);
-            return total_size;
-        }
-
-        void clear() override {
-            pthread_mutex_lock(mutex);
-            for (auto it = table->begin(); it != table->end(); it++) {
-                delete it->second;
-            }
-            table->clear();
-            pthread_mutex_unlock(mutex);
-        }
-
-    private:
-        std::map<std::string, T*> *table;
-        pthread_mutex_t *mutex;
+    bool put(const std::string &key, T *value) override {
+        pthread_rwlock_wrlock(rwlock);
+        (*table)[key] = value;
+        pthread_rwlock_unlock(rwlock);
+        return true;
     };
-}
+
+    size_t size() override {
+        pthread_rwlock_rdlock(rwlock);
+        auto res = table->size();
+        pthread_rwlock_unlock(rwlock);
+        return res;
+    }
+
+    size_t sizeBytes(std::function<size_t(const T *)> size) override {
+        pthread_rwlock_rdlock(rwlock);
+        size_t total_size = 0;
+        for (auto it = table->begin(); it != table->end(); it++) {
+            total_size += size(it->second);
+        }
+        pthread_rwlock_unlock(rwlock);
+        return total_size;
+    }
+
+    void clear() override {
+        pthread_rwlock_wrlock(rwlock);
+        for (auto it = table->begin(); it != table->end(); it++) {
+            delete it->second;
+        }
+        table->clear();
+        pthread_rwlock_unlock(rwlock);
+    }
+
+private:
+    std::map<std::string, T *> *table;
+    pthread_rwlock_t *rwlock{};
+};
 
 #endif //HTTP_CPP_PROXY_MAP_CACHE_H

--- a/a.ivanov/33/src/cache/map_cache.h
+++ b/a.ivanov/33/src/cache/map_cache.h
@@ -16,12 +16,25 @@ public:
         rwlock = new pthread_rwlock_t;
         int code = pthread_rwlock_init(rwlock, nullptr);
         assert(code == 0);
+        mutex = new pthread_mutex_t;
+        code = pthread_mutex_init(mutex, nullptr);
+        assert(code == 0);
     }
 
     ~MapCache() {
         delete table;
         pthread_rwlock_destroy(rwlock);
         delete rwlock;
+        pthread_mutex_destroy(mutex);
+        delete mutex;
+    }
+
+    void lock() override {
+        pthread_mutex_lock(mutex);
+    }
+
+    void unlock() override {
+        pthread_mutex_unlock(mutex);
     }
 
     T *get(const std::string &key) override {
@@ -80,6 +93,7 @@ public:
 private:
     std::map<std::string, T *> *table;
     pthread_rwlock_t *rwlock{};
+    pthread_mutex_t *mutex;
 };
 
 #endif //HTTP_CPP_PROXY_MAP_CACHE_H

--- a/a.ivanov/33/src/cache/map_cache.h
+++ b/a.ivanov/33/src/cache/map_cache.h
@@ -14,41 +14,41 @@ namespace aiwannafly {
 
         MapCache() {
             this->table = new std::map<std::string, T*>();
-            rwlock = new pthread_rwlock_t;
-            int code = pthread_rwlock_init(rwlock, nullptr);
+            mutex = new pthread_mutex_t;
+            int code = pthread_mutex_init(mutex, nullptr);
             assert(code == 0);
         }
 
         ~MapCache() {
             delete table;
-            pthread_rwlock_destroy(rwlock);
-            delete rwlock;
+            pthread_mutex_destroy(mutex);
+            delete mutex;
         }
 
         T *get(const std::string& key) override {
-            pthread_rwlock_rdlock(rwlock);
+            pthread_mutex_lock(mutex);
             auto *res = table->at(key);
-            pthread_rwlock_unlock(rwlock);
+            pthread_mutex_unlock(mutex);
             return res;
         }
 
         void erase(const std::string &key) override {
-            pthread_rwlock_wrlock(rwlock);
+            pthread_mutex_lock(mutex);
             table->erase(key);
-            pthread_rwlock_unlock(rwlock);
+            pthread_mutex_unlock(mutex);
         }
 
         bool contains(const std::string &key) override {
-            pthread_rwlock_rdlock(rwlock);
+            pthread_mutex_lock(mutex);
             bool res = table->contains(key);
-            pthread_rwlock_unlock(rwlock);
+            pthread_mutex_unlock(mutex);
             return res;
         }
 
         bool put(const std::string & key, T *value) override {
-            pthread_rwlock_wrlock(rwlock);
+            pthread_mutex_lock(mutex);
             (*table)[key] = value;
-            pthread_rwlock_unlock(rwlock);
+            pthread_mutex_unlock(mutex);
             return true;
         };
 
@@ -57,27 +57,27 @@ namespace aiwannafly {
         }
 
         size_t sizeBytes(std::function<size_t(const T *)> size) override {
-            pthread_rwlock_rdlock(rwlock);
+            pthread_mutex_lock(mutex);
             size_t total_size = 0;
             for (auto it = table->begin(); it != table->end(); it++) {
                 total_size += size(it->second);
             }
-            pthread_rwlock_unlock(rwlock);
+            pthread_mutex_unlock(mutex);
             return total_size;
         }
 
         void clear() override {
-            pthread_rwlock_wrlock(rwlock);
+            pthread_mutex_lock(mutex);
             for (auto it = table->begin(); it != table->end(); it++) {
                 delete it->second;
             }
             table->clear();
-            pthread_rwlock_unlock(rwlock);
+            pthread_mutex_unlock(mutex);
         }
 
     private:
         std::map<std::string, T*> *table;
-        pthread_rwlock_t *rwlock;
+        pthread_mutex_t *mutex;
     };
 }
 

--- a/a.ivanov/33/src/cache/map_cache.h
+++ b/a.ivanov/33/src/cache/map_cache.h
@@ -1,0 +1,83 @@
+#ifndef HTTP_CPP_PROXY_MAP_CACHE_H
+#define HTTP_CPP_PROXY_MAP_CACHE_H
+
+#include <map>
+#include <cassert>
+
+#include "cache.h"
+
+namespace aiwannafly {
+    template <class T>
+    class MapCache final : public Cache<T> {
+    public:
+
+        MapCache() {
+            this->table = new std::map<std::string, T*>();
+            rwlock = new pthread_rwlock_t;
+            int code = pthread_rwlock_init(rwlock, nullptr);
+            assert(code == 0);
+        }
+
+        ~MapCache() {
+            delete table;
+            pthread_rwlock_destroy(rwlock);
+            delete rwlock;
+        }
+
+        T *get(const std::string& key) override {
+            pthread_rwlock_rdlock(rwlock);
+            auto *res = table->at(key);
+            pthread_rwlock_unlock(rwlock);
+            return res;
+        }
+
+        void erase(const std::string &key) override {
+            pthread_rwlock_wrlock(rwlock);
+            table->erase(key);
+            pthread_rwlock_unlock(rwlock);
+        }
+
+        bool contains(const std::string &key) override {
+            pthread_rwlock_rdlock(rwlock);
+            bool res = table->contains(key);
+            pthread_rwlock_unlock(rwlock);
+            return res;
+        }
+
+        bool put(const std::string & key, T *value) override {
+            pthread_rwlock_wrlock(rwlock);
+            (*table)[key] = value;
+            pthread_rwlock_unlock(rwlock);
+            return true;
+        };
+
+        size_t size() override {
+            return table->size();
+        }
+
+        size_t sizeBytes(std::function<size_t(const T *)> size) override {
+            pthread_rwlock_rdlock(rwlock);
+            size_t total_size = 0;
+            for (auto it = table->begin(); it != table->end(); it++) {
+                total_size += size(it->second);
+            }
+            pthread_rwlock_unlock(rwlock);
+            return total_size;
+        }
+
+        void clear() override {
+            pthread_rwlock_wrlock(rwlock);
+            for (auto it = table->begin(); it != table->end(); it++) {
+                delete it->second;
+            }
+            table->clear();
+            pthread_rwlock_unlock(rwlock);
+        }
+
+    private:
+        std::map<std::string, T*> *table;
+        pthread_rwlock_t *rwlock;
+    };
+}
+
+#endif //HTTP_CPP_PROXY_MAP_CACHE_H

--- a/a.ivanov/33/src/compile.sh
+++ b/a.ivanov/33/src/compile.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+clang++ -Wall -pedantic -fsanitize=address -std=c++2a main.cpp proxy_main.cpp utils/socket_operations.cpp utils/io_operations.cpp utils/log.cpp proxy_worker/proxy_worker.cpp -lpthread -o ../build/proxy
+echo "Program build/proxy compiled"
+

--- a/a.ivanov/33/src/main.cpp
+++ b/a.ivanov/33/src/main.cpp
@@ -1,0 +1,69 @@
+#include <string>
+
+#include "proxy_main.h"
+
+#define USAGE_GUIDE "usage: ./prog <proxy_port> <worker_threads_count>"
+
+namespace {
+    const int REQUIRED_ARGC = 1 + 1 + 1;
+
+    typedef struct args_t {
+        bool valid;
+        int proxy_port;
+        size_t worker_threads_count;
+    } args_t;
+
+    bool ExtractInt(const char *buf, int *num) {
+        if (nullptr == buf || num == nullptr) {
+            return false;
+        }
+        char *end_ptr = nullptr;
+        *num = (int) strtol(buf, &end_ptr, 10);
+        if (buf + strlen(buf) > end_ptr) {
+            return false;
+        }
+        return true;
+    }
+
+    bool ExtractUint(const char *buf, size_t *num) {
+        if (nullptr == buf || num == nullptr) {
+            return false;
+        }
+        char *end_ptr = nullptr;
+        *num = (int) strtoul(buf, &end_ptr, 10);
+        if (buf + strlen(buf) > end_ptr) {
+            return false;
+        }
+        return true;
+    }
+
+    args_t ParseArgs(int argc, char *argv[]) {
+        args_t result;
+        result.valid = false;
+        if (argc < REQUIRED_ARGC) {
+            return result;
+        }
+        bool extracted = ExtractInt(argv[1], &result.proxy_port);
+        if (!extracted) {
+            return result;
+        }
+        extracted = ExtractUint(argv[2], &result.worker_threads_count);
+        if (!extracted) {
+            return result;
+        }
+        result.valid = true;
+        return result;
+    }
+}
+
+int main(int argc, char *argv[]) {
+    args_t args = ParseArgs(argc, argv);
+    if (!args.valid) {
+        fprintf(stderr, "%s\n", USAGE_GUIDE);
+        return EXIT_FAILURE;
+    }
+    Proxy *p = new worker_thread_proxy::HttpProxy(args.worker_threads_count);
+    p->run(args.proxy_port);
+    delete p;
+    pthread_exit(nullptr);
+}

--- a/a.ivanov/33/src/proxy.h
+++ b/a.ivanov/33/src/proxy.h
@@ -1,0 +1,12 @@
+#ifndef HTTP_CPP_PROXY_PROXY_H
+#define HTTP_CPP_PROXY_PROXY_H
+
+class Proxy {
+public:
+
+    virtual ~Proxy() = default;
+
+    virtual void run(int port) = 0;
+};
+
+#endif //HTTP_CPP_PROXY_PROXY_H

--- a/a.ivanov/33/src/proxy_main.cpp
+++ b/a.ivanov/33/src/proxy_main.cpp
@@ -1,0 +1,211 @@
+#include "proxy_main.h"
+
+#include <cassert>
+#include <cstring>
+#include <unistd.h>
+#include <csignal>
+#include <sys/socket.h>
+#include "sys/eventfd.h"
+#include <netinet/in.h>
+
+#include "status_code.h"
+#include "utils/socket_operations.h"
+#include "utils/log.h"
+
+#define TERMINATE_CMD "stop"
+
+namespace worker_thread_proxy {
+    static const int MAX_LISTEN_QUEUE_SIZE = 500;
+    int signal_pipe[2];
+
+    HttpProxy::HttpProxy(size_t worker_threads_count) {
+        assert(worker_threads_count >= 1);
+        this->worker_threads_count = worker_threads_count;
+        selected = new io::SelectData();
+        cache = new aiwannafly::MapCache<Resource>();
+        workers = std::vector<Worker*>();
+    }
+
+    HttpProxy::~HttpProxy() {
+        delete selected;
+        delete cache;
+    }
+
+    void sendTerminate(__attribute__((unused)) int sig) {
+        auto *terminate = new io::Message();
+        char *cmd = (char *) malloc(strlen(TERMINATE_CMD) + 1);
+        if (cmd == nullptr) {
+            return;
+        }
+        strcpy(cmd, TERMINATE_CMD);
+        terminate->data = cmd;
+        terminate->len = strlen(TERMINATE_CMD);
+        io::WriteAll(signal_pipe[io::WRITE_PIPE_END], terminate);
+        delete terminate;
+    }
+
+    void doNothing(int sig) {}
+
+    int initSignalHandlers() {
+        int return_value = pipe(signal_pipe);
+        if (return_value == status_code::FAIL) {
+            return status_code::FAIL;
+        }
+//        signal(SIGINT, sendTerminate);
+//        signal(SIGTERM, sendTerminate);
+        signal(SIGPIPE, doNothing);
+        return status_code::SUCCESS;
+    }
+
+    void *launchWorker(void * arg) {
+        auto worker = (ProxyWorker *) arg;
+        long code = worker->run();
+        return (void *) code;
+    }
+
+    int HttpProxy::launchWorkerThreads() {
+        assert(worker_threads_count >= 1);
+        for (size_t i = 0; i < worker_threads_count; i++) {
+            auto worker = new Worker();
+            int notice_fd = eventfd(0, 0);
+            worker->runner = new ProxyWorker(notice_fd, signal_pipe[io::READ_PIPE_END], cache);
+            int code = pthread_create(&worker->tid, nullptr, launchWorker, worker->runner);
+            if (code < 0) {
+                return status_code::FAIL;
+            }
+            workers.push_back(worker);
+        }
+        return status_code::SUCCESS;
+    }
+
+    void HttpProxy::run(int port) {
+        int ret_val = initAndBindProxySocket(port);
+        if (ret_val == status_code::FAIL) {
+            logError("Could not init and bind proxy socket");
+            return;
+        }
+        ret_val = initSignalHandlers();
+        if (ret_val == status_code::FAIL) {
+            logErrorWithErrno("Could not init signal handlers");
+            return;
+        }
+        ret_val = launchWorkerThreads();
+        if (ret_val == status_code::FAIL) {
+            logErrorWithErrno("Could launch worker threads");
+            return;
+        }
+        ret_val = listen(proxy_socket, MAX_LISTEN_QUEUE_SIZE);
+        if (ret_val == status_code::FAIL) {
+            logErrorWithErrno("Error in listen");
+            ret_val = close(proxy_socket);
+            if (ret_val == status_code::FAIL) {
+                logErrorWithErrno("Error in close");
+            }
+        }
+        selected->addFd(proxy_socket, io::SelectData::READ);
+        selected->addFd(signal_pipe[io::READ_PIPE_END], io::SelectData::READ);
+        log("Running on " + std::to_string(port));
+        while (true) {
+            ret_val = select(selected->getMaxFd() + 1, selected->getReadSet(), nullptr,
+                             nullptr, nullptr);
+            if (ret_val == status_code::FAIL || ret_val == status_code::TIMEOUT) {
+                if (errno != EINTR && ret_val == status_code::FAIL) {
+                    logErrorWithErrno("Error in select");
+                    freeResources();
+                    return;
+                }
+                if (ret_val == status_code::TIMEOUT) {
+                    log("Select timed out. End program.");
+                    freeResources();
+                    return;
+                }
+            }
+            if (FD_ISSET(proxy_socket, selected->getReadSet())) {
+                log("Handle new connection");
+                ret_val = acceptNewClient();
+                if (ret_val == status_code::FAIL) {
+                    logErrorWithErrno("Failed to accept new connection");
+                    break;
+                }
+            }
+        }
+    }
+
+    int HttpProxy::acceptNewClient() {
+        int new_client_fd = accept(proxy_socket, nullptr, nullptr);
+        if (new_client_fd == status_code::FAIL) {
+            if (errno != EAGAIN) {
+                perror("[PROXY] Error in accept. Shutdown server...");
+            }
+            return status_code::FAIL;
+        }
+        int return_value = socket_operations::SetNonblocking(new_client_fd);
+        if (return_value == status_code::FAIL) {
+            close(new_client_fd);
+            return status_code::FAIL;
+        }
+        int notice_fd = workers.at(current_worker_id)->runner->getNoticeFd();
+        current_worker_id++;
+        if (current_worker_id == worker_threads_count) {
+            current_worker_id = 0;
+        }
+        assert(notice_fd > 0);
+        int code = eventfd_write(notice_fd, new_client_fd);
+        if (code < 0) {
+            return status_code::FAIL;
+        }
+        log("Sent fd " + std::to_string(new_client_fd) + " to a worker thread");
+        return status_code::SUCCESS;
+    }
+
+    void HttpProxy::freeResources() {
+        log("Shutdown...");
+        for (auto worker: workers) {
+            int code = pthread_join(worker->tid, nullptr);
+            if (code < 0) {
+                logErrorWithErrno("Error in pthread_join()");
+            }
+            delete worker;
+        }
+        cache->clear();
+        int ret_val = close(proxy_socket);
+        if (ret_val == status_code::FAIL) {
+            logErrorWithErrno("Error in close(proxy_socket)");
+        }
+    }
+
+    // returns proxy socket fd if success, status_code::FAIL otherwise
+    int HttpProxy::initAndBindProxySocket(int port) {
+        proxy_socket = socket(AF_INET, SOCK_STREAM, 0);
+        if (proxy_socket == status_code::FAIL) {
+            logErrorWithErrno("Error in socket()");
+            return status_code::FAIL;
+        }
+        int return_value = socket_operations::SetReusable(proxy_socket);
+        if (return_value == status_code::FAIL) {
+            close(proxy_socket);
+            logError("Failed to make socket reusable");
+            return status_code::FAIL;
+        }
+        return_value = socket_operations::SetNonblocking(proxy_socket);
+        if (return_value == status_code::FAIL) {
+            close(proxy_socket);
+            logError("Failed to make socket reusable");
+            return status_code::FAIL;
+        }
+        struct sockaddr_in proxy_sockaddr{};
+        proxy_sockaddr.sin_family = AF_INET;
+        proxy_sockaddr.sin_addr.s_addr = INADDR_ANY;
+        proxy_sockaddr.sin_port = htons(port);
+        return_value = bind(proxy_socket, (struct sockaddr *) &proxy_sockaddr, sizeof(proxy_sockaddr));
+        if (return_value < 0) {
+            logErrorWithErrno("Error in bind");
+            return_value = close(proxy_socket);
+            if (return_value == status_code::FAIL) {
+                logErrorWithErrno("Error in close");
+            }
+            return status_code::FAIL;
+        }
+        return proxy_socket;
+    }
+}

--- a/a.ivanov/33/src/proxy_main.cpp
+++ b/a.ivanov/33/src/proxy_main.cpp
@@ -22,7 +22,7 @@ namespace worker_thread_proxy {
         assert(worker_threads_count >= 1);
         this->worker_threads_count = worker_threads_count;
         selected = new io::SelectData();
-        cache = new aiwannafly::MapCache<Resource>();
+        cache = new aiwannafly::MapCache<ResourceInfo>();
         workers = std::vector<Worker*>();
     }
 

--- a/a.ivanov/33/src/proxy_main.h
+++ b/a.ivanov/33/src/proxy_main.h
@@ -6,12 +6,12 @@
 #include <set>
 #include <vector>
 
+#include "cache/map_cache.h"
 #include "proxy_worker/proxy_worker.h"
 #include "proxy.h"
+#include "resource/resource_info.h"
 #include "utils/select_data.h"
 #include "utils/io_operations.h"
-#include "cache/map_cache.h"
-#include "resource/resource_info.h"
 
 #include "../httpparser/src/httpparser/httpresponseparser.h"
 #include "../httpparser/src/httpparser/response.h"
@@ -52,7 +52,7 @@ namespace worker_thread_proxy {
         int signal_fd = -1;
         int proxy_socket = 0;
         io::SelectData *selected;
-        aiwannafly::Cache<ResourceInfo> *cache;
+        Cache<ResourceInfo> *cache;
         std::vector<Worker*> workers;
     };
 }

--- a/a.ivanov/33/src/proxy_main.h
+++ b/a.ivanov/33/src/proxy_main.h
@@ -1,0 +1,59 @@
+#ifndef HTTP_CPP_PROXY_MAIN_H
+#define HTTP_CPP_PROXY_MAIN_H
+
+#include <cstdlib>
+#include <map>
+#include <set>
+#include <vector>
+
+#include "proxy_worker/proxy_worker.h"
+#include "proxy.h"
+#include "utils/select_data.h"
+#include "utils/io_operations.h"
+#include "cache/map_cache.h"
+#include "resource/resource.h"
+
+#include "../httpparser/src/httpparser/httpresponseparser.h"
+#include "../httpparser/src/httpparser/response.h"
+
+namespace worker_thread_proxy {
+
+    typedef struct Worker {
+        ProxyWorker *runner;
+        pthread_t tid;
+
+        ~Worker() {
+            delete runner;
+        }
+    } Worker;
+
+    class HttpProxy final : public Proxy {
+    public:
+
+        explicit HttpProxy(size_t worker_threads_count);
+
+        ~HttpProxy() final;
+
+        void run(int port) final;
+
+    private:
+
+        int initAndBindProxySocket(int port);
+
+        int acceptNewClient();
+
+        void freeResources();
+
+        int launchWorkerThreads();
+
+        size_t worker_threads_count = 1;
+        size_t current_worker_id = 0;
+
+        int proxy_socket = 0;
+        io::SelectData *selected;
+        aiwannafly::Cache<Resource> *cache;
+        std::vector<Worker*> workers;
+    };
+}
+
+#endif //HTTP_CPP_PROXY_MAIN_H

--- a/a.ivanov/33/src/proxy_main.h
+++ b/a.ivanov/33/src/proxy_main.h
@@ -49,6 +49,7 @@ namespace worker_thread_proxy {
         size_t worker_threads_count = 1;
         size_t current_worker_id = 0;
 
+        int signal_fd = -1;
         int proxy_socket = 0;
         io::SelectData *selected;
         aiwannafly::Cache<ResourceInfo> *cache;

--- a/a.ivanov/33/src/proxy_main.h
+++ b/a.ivanov/33/src/proxy_main.h
@@ -11,7 +11,7 @@
 #include "utils/select_data.h"
 #include "utils/io_operations.h"
 #include "cache/map_cache.h"
-#include "resource/resource.h"
+#include "resource/resource_info.h"
 
 #include "../httpparser/src/httpparser/httpresponseparser.h"
 #include "../httpparser/src/httpparser/response.h"
@@ -51,7 +51,7 @@ namespace worker_thread_proxy {
 
         int proxy_socket = 0;
         io::SelectData *selected;
-        aiwannafly::Cache<Resource> *cache;
+        aiwannafly::Cache<ResourceInfo> *cache;
         std::vector<Worker*> workers;
     };
 }

--- a/a.ivanov/33/src/proxy_worker/peers.h
+++ b/a.ivanov/33/src/proxy_worker/peers.h
@@ -1,0 +1,30 @@
+#ifndef WORKER_THREADS_PROXY_PEERS_H
+#define WORKER_THREADS_PROXY_PEERS_H
+
+#include <vector>
+#include "../utils/io_operations.h"
+
+namespace worker_thread_proxy {
+
+    typedef struct ServerInfo {
+        std::vector<io::Message *> message_queue = std::vector<io::Message *>();
+        bool connected = false;
+        std::string res_name;
+
+        ServerInfo() = default;
+
+        ~ServerInfo() = default;
+    } ServerInfo;
+
+    typedef struct ClientInfo {
+        std::vector<io::Message *> message_queue = std::vector<io::Message *>();
+        std::string res_name;
+        size_t recv_msg_count = 0;
+
+        ClientInfo() = default;
+
+        ~ClientInfo() = default;
+    } ClientInfo;
+}
+
+#endif //WORKER_THREADS_PROXY_PEERS_H

--- a/a.ivanov/33/src/proxy_worker/peers.h
+++ b/a.ivanov/33/src/proxy_worker/peers.h
@@ -8,7 +8,7 @@
 namespace worker_thread_proxy {
 
     typedef struct ServerInfo {
-        std::vector<io::Message *> message_queue = std::vector<io::Message *>();
+        std::vector<io::Message *> msg_queue = std::vector<io::Message *>();
         bool connected = false;
         std::string res_name;
 
@@ -18,7 +18,7 @@ namespace worker_thread_proxy {
     } ServerInfo;
 
     typedef struct ClientInfo {
-        std::vector<io::Message *> message_queue = std::vector<io::Message *>();
+        std::vector<io::Message *> msg_queue = std::vector<io::Message *>();
         std::string res_name;
         size_t recv_msg_count = 0;
 

--- a/a.ivanov/33/src/proxy_worker/peers.h
+++ b/a.ivanov/33/src/proxy_worker/peers.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include "../utils/io_operations.h"
+#include "../sync/threadsafe_list.h"
 
 namespace worker_thread_proxy {
 

--- a/a.ivanov/33/src/proxy_worker/proxy_worker.cpp
+++ b/a.ivanov/33/src/proxy_worker/proxy_worker.cpp
@@ -66,6 +66,7 @@ namespace worker_thread_proxy {
             for (int fd = 0; fd <= selected->getMaxFd() && desc_ready > 0; ++fd) {
                 if (FD_ISSET(fd, &constant_read_set)) {
                     desc_ready -= 1;
+                    //log("Got message");
                     ret_val = readMessageFrom(fd);
                     if (ret_val == status_code::TERMINATE) {
                         logError("Terminate");
@@ -213,6 +214,7 @@ namespace worker_thread_proxy {
                           resource->parts.end(), std::back_inserter(clients->at(fd).message_queue));
             }
             msg_count = clients->at(fd).message_queue.size();
+
             if (msg_count >= 1) {
                 auto msg = clients->at(fd).message_queue.front();
                 clients->at(fd).message_queue.erase(clients->at(fd).message_queue.begin());
@@ -329,7 +331,7 @@ namespace worker_thread_proxy {
             if (!resource->parts.empty()) {
                 selected->addFd(client_fd, io::SelectData::WRITE);
             }
-            log("Got " + std::to_string(clients->at(client_fd).message_queue.size()) + " chunks of resource");
+            log("Found " + std::to_string(resource->parts.size()) + " chunks of resource");
             return status_code::FAIL;
         }
         for (const httpparser::Request::HeaderItem &header: request.headers) {

--- a/a.ivanov/33/src/proxy_worker/proxy_worker.cpp
+++ b/a.ivanov/33/src/proxy_worker/proxy_worker.cpp
@@ -1,0 +1,485 @@
+#include "proxy_worker.h"
+
+#include <unistd.h>
+#include <csignal>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <cstring>
+#include <netdb.h>
+#include <fcntl.h>
+#include <cassert>
+#include <sys/eventfd.h>
+
+#include "../../httpparser/src/httpparser/request.h"
+#include "../../httpparser/src/httpparser/httprequestparser.h"
+
+#include "../status_code.h"
+#include "../utils/socket_operations.h"
+#include "../utils/log.h"
+#include "../resource/simple_resource.h"
+
+#define TERMINATE_CMD "stop"
+
+namespace worker_thread_proxy {
+    static const int HTTP_PORT = 80;
+
+    ProxyWorker::ProxyWorker(int notice_fd, int signal_fd, aiwannafly::Cache<Resource> *cache) {
+        assert(cache);
+        selected = new io::SelectData();
+        clients = new std::map<int, ClientInfo>();
+        servers = new std::map<int, ServerInfo>();
+        resource_names = new std::map<int, std::string>();
+        this->notice_fd = notice_fd;
+        this->signal_fd = signal_fd;
+        this->cache = cache;
+        DNS_map = new std::map<std::string, struct hostent *>();
+    }
+
+    ProxyWorker::~ProxyWorker() {
+        delete selected;
+        delete clients;
+        delete servers;
+        delete cache;
+        delete DNS_map;
+        delete resource_names;
+    }
+
+    int ProxyWorker::run() {
+        selected->addFd(notice_fd, io::SelectData::READ);
+        selected->addFd(signal_fd, io::SelectData::READ);
+        fd_set constant_read_set;
+        fd_set constant_write_set;
+        while (true) {
+            memcpy(&constant_read_set, selected->getReadSet(), sizeof(*selected->getReadSet()));
+            memcpy(&constant_write_set, selected->getWriteSet(), sizeof(*selected->getWriteSet()));
+            int ret_val = select(selected->getMaxFd() + 1, &constant_read_set, &constant_write_set,
+                             nullptr, nullptr);
+            if (ret_val == status_code::FAIL || ret_val == status_code::TIMEOUT) {
+                if (errno != EINTR && ret_val == status_code::FAIL) {
+                    logErrorWithErrno("Error in select");
+                    freeResources();
+                    return status_code::FAIL;
+                }
+                if (ret_val == status_code::TIMEOUT) {
+                    log("Select timed out. End program.");
+                    freeResources();
+                    return status_code::FAIL;
+                }
+            }
+            int desc_ready = ret_val;
+            for (int fd = 0; fd <= selected->getMaxFd() && desc_ready > 0; ++fd) {
+                if (FD_ISSET(fd, &constant_read_set)) {
+                    desc_ready -= 1;
+                    ret_val = readMessageFrom(fd);
+                    if (ret_val == status_code::TERMINATE) {
+                        logError("Terminate");
+                        freeResources();
+                        return status_code::TERMINATE;
+                    }
+                }
+                if (FD_ISSET(fd, &constant_write_set)) {
+                    desc_ready -= 1;
+                    ret_val = writeMessageTo(fd);
+                    if (ret_val == status_code::FAIL) {
+                        logError("Error occurred while handling the write message");
+                    }
+                }
+            }
+        }
+    }
+
+    void ProxyWorker::freeResources() {
+        log("Shutdown...");
+        for (int fd = 3; fd <= selected->getMaxFd(); fd++) {
+            if (FD_ISSET(fd, selected->getReadSet()) ||
+                FD_ISSET(fd, selected->getWriteSet())) {
+                int ret_val = closeConnection(fd);
+                if (ret_val == status_code::FAIL) {
+                    logErrorWithErrno("Error in close_connection");
+                }
+            }
+        }
+    }
+
+    int ProxyWorker::closeConnection(int fd) {
+        assert(fd > 0);
+        servers->erase(fd);
+        if (servers->contains(fd)) {
+            for (const auto &msg: servers->at(fd).message_queue) {
+                delete msg;
+            }
+        }
+        if (clients->contains(fd)) {
+            logError("Client " + std::to_string(fd) + " disconnects");
+            auto res_name = clients->at(fd).res_name;
+            if (cache->contains(res_name)) {
+                cache->get(res_name)->cancel();
+            }
+        }
+        clients->erase(fd);
+        selected->remove_fd(fd, io::SelectData::READ);
+        selected->remove_fd(fd, io::SelectData::WRITE);
+        return close(fd);
+    }
+
+    int ProxyWorker::readMessageFrom(int fd) {
+        assert(fd > 0);
+        if (fd == notice_fd) {
+            eventfd_t new_client_fd;
+            int code = eventfd_read(fd, &new_client_fd);
+            if (code < 0) {
+                return status_code::FAIL;
+            } else {
+                (*clients)[(int) new_client_fd] = ClientInfo();
+                selected->addFd((int) new_client_fd, io::SelectData::READ);
+                return status_code::SUCCESS;
+            }
+        }
+        if (resource_names->contains(fd)) {
+            log("Client got notification from a resource");
+            return readResourceNotification(fd);
+        }
+        io::Message *message = io::read_all(fd);
+        if (message == nullptr) {
+            return status_code::FAIL;
+        }
+        if (message->len == 0) {
+            int ret_val = closeConnection(fd);
+            if (ret_val == status_code::FAIL) {
+                logErrorWithErrno("Error in close connection");
+                return status_code::FAIL;
+            }
+            delete message;
+            return ret_val;
+        }
+        if (fd == signal_fd) {
+            if (std::string(message->data) == TERMINATE_CMD) {
+                delete message;
+                return status_code::TERMINATE;
+            }
+        }
+        // so, we've got message. what's next?
+        // let's check out who sent it
+         if (servers->contains(fd)) {
+            int ret_val = readServerResponse(fd, message);
+            if (ret_val == status_code::FAIL) {
+                delete message;
+            }
+            return ret_val;
+        } else if (clients->contains(fd)) {
+            int ret_val = readClientRequest(fd, message);
+            if (ret_val == status_code::FAIL) {
+                delete message;
+            }
+            return ret_val;
+        }
+        delete message;
+        return status_code::FAIL;
+    }
+
+    int ProxyWorker::readResourceNotification(int fd) {
+        eventfd_t value;
+        int code = eventfd_read(fd, &value);
+        if (code < 0) {
+            return status_code::FAIL;
+        }
+        assert(resource_names->contains(fd));
+        std::string res_name = resource_names->at(fd);
+        auto *resource = cache->get(res_name);
+        for (auto &client : *clients) {
+            if (client.second.res_name == res_name) {
+                log("Client should get " + std::to_string(resource->getParts()->size()) + " parts");
+                if (client.second.recv_msg_count < resource->getParts()->size()) {
+                    selected->addFd(client.first, io::SelectData::WRITE);
+                }
+                for (size_t i = client.second.recv_msg_count; i < resource->getParts()->size(); i++) {
+                    log("Push new part into a queue");
+                    clients->at(client.first).message_queue.push_back(resource->getParts()->at(i));
+                }
+            }
+        }
+        return status_code::SUCCESS;
+    }
+
+    int ProxyWorker::writeMessageTo(int fd) {
+        selected->remove_fd(fd, io::SelectData::WRITE);
+        if (servers->contains(fd)) {
+            assert(!clients->contains(fd));
+            if (!servers->at(fd).connected) {
+                int ret_val = finishConnectToServer(fd);
+                if (ret_val == status_code::FAIL) {
+                    logErrorWithErrno("Failed to make connection");
+                } else {
+                    if (!servers->at(fd).message_queue.empty()) {
+                        selected->addFd(fd, io::SelectData::WRITE);
+                    }
+                }
+            } else {
+                size_t msg_count = servers->at(fd).message_queue.size();
+                if (msg_count >= 1) {
+                    io::Message *message = servers->at(fd).message_queue.back();
+                    servers->at(fd).message_queue.pop_back();
+                    bool written = io::WriteAll(fd, message);
+                    delete message;
+                    if (msg_count - 1 > 0) {
+                        selected->addFd(fd, io::SelectData::WRITE);
+                    }
+                    if (!written) {
+                        logErrorWithErrno("Error in write all");
+                        return status_code::FAIL;
+                    }
+                }
+            }
+        }
+        if (clients->contains(fd)) {
+            assert(!servers->contains(fd));
+            size_t msg_count = clients->at(fd).message_queue.size();
+            if (msg_count >= 1) {
+                auto msg = clients->at(fd).message_queue.front();
+                clients->at(fd).message_queue.erase(clients->at(fd).message_queue.begin());
+                bool written = io::WriteAll(fd, msg);
+                if (!cache->contains(clients->at(fd).res_name)) {
+                    delete msg;
+                }
+                if (msg_count - 1 > 0) {
+                    selected->addFd(fd, io::SelectData::WRITE);
+                }
+                if (!written) {
+                    logErrorWithErrno("Error in write all");
+                    return status_code::FAIL;
+                } else {
+                    clients->at(fd).recv_msg_count++;
+//                    log("Sent to client " + std::to_string(len) + " bytes");
+                }
+            }
+        }
+        return status_code::SUCCESS;
+    }
+
+    int ProxyWorker::beginConnectToServer(const std::string &hostname, int port) {
+        if (port < 0 || port >= 65536) {
+            return status_code::FAIL;
+        }
+        int sd = socket(AF_INET, SOCK_STREAM, 0);
+        if (sd == status_code::FAIL) {
+            return status_code::FAIL;
+        }
+        int return_code = socket_operations::SetNonblocking(sd);
+        if (return_code == status_code::FAIL) {
+            return status_code::FAIL;
+        }
+        struct hostent *hostnm;
+        if (DNS_map->contains(hostname)) {
+            hostnm = DNS_map->at(hostname);
+        } else {
+            hostnm = gethostbyname(hostname.data());
+            if (hostnm == nullptr) {
+                logErrorWithErrno("Failed to get by hostname");
+                return status_code::FAIL;
+            }
+        }
+        (*DNS_map)[hostname] = hostnm;
+        struct sockaddr_in serv_sockaddr{};
+        serv_sockaddr.sin_family = AF_INET;
+        serv_sockaddr.sin_port = htons(port);
+        serv_sockaddr.sin_addr.s_addr = *((unsigned long *) hostnm->h_addr);
+        return_code = connect(sd, (const struct sockaddr *) &serv_sockaddr, sizeof(serv_sockaddr));
+        if (return_code < 0) {
+            if (errno == EINPROGRESS) {
+                selected->addFd(sd, io::SelectData::WRITE);
+                (*servers)[sd] = ServerInfo();
+                (*servers)[sd].connected = false;
+                return sd;
+            }
+            return status_code::FAIL;
+        }
+        selected->addFd(sd, io::SelectData::READ);
+        (*servers)[sd] = ServerInfo();
+        (*servers)[sd].connected = true;
+        return sd;
+    }
+
+    int ProxyWorker::finishConnectToServer(int fd) {
+        assert((*servers).contains(fd));
+        int opt = fcntl(fd, F_GETFL, NULL);
+        if (opt < 0) {
+            return status_code::FAIL;
+        }
+        socklen_t len = sizeof(opt);
+        int return_code = getsockopt(fd, SOL_SOCKET, SO_ERROR, &opt, &len);
+        if (return_code < 0) {
+            return status_code::FAIL;
+        }
+        if (opt != status_code::SUCCESS) {
+            errno = opt;
+            return status_code::FAIL;
+        }
+        selected->addFd(fd, io::SelectData::READ);
+        servers->at(fd).connected = true;
+        return status_code::SUCCESS;
+    }
+
+    int ProxyWorker::readClientRequest(int client_fd, io::Message *request_message) {
+        assert(request_message);
+        assert(clients->contains(client_fd));
+        httpparser::Request request;
+        httpparser::HttpRequestParser parser;
+        httpparser::HttpRequestParser::ParseResult res = parser.parse(request,
+                                                                      request_message->data,
+                                                                      request_message->data + request_message->len);
+        if (res != httpparser::HttpRequestParser::ParsingCompleted) {
+            return status_code::FAIL;
+        }
+        log(request.method + " for " + std::to_string(client_fd));
+        log(request.uri);
+        std::string res_name = request.uri;
+        if (request.method != "GET") {
+            return status_code::FAIL;
+        }
+        if (cache->contains(res_name)) {
+            // we've already tried to get the resource
+            log("Found " + res_name + " in cache");
+            Resource *resource = cache->get(res_name);
+            int res_fd = resource->getNotifyFd();
+            selected->addFd(res_fd, io::SelectData::READ);
+            (*resource_names)[res_fd] = res_name;
+            log("It's size : " + std::to_string(resource->getCurrentLength()));
+            clients->at(client_fd).res_name = res_name;
+            clients->at(client_fd).message_queue.clear();
+            if (resource->getParts()->size() > 0) {
+                selected->addFd(client_fd, io::SelectData::WRITE);
+            }
+            for (size_t i = 0; i < resource->getParts()->size(); i++) {
+                clients->at(client_fd).message_queue.push_back(resource->getParts()->at(i));
+            }
+            log("Got " + std::to_string(clients->at(client_fd).message_queue.size()) + " chunks of resource");
+            return status_code::FAIL;
+        }
+        for (const httpparser::Request::HeaderItem &header: request.headers) {
+            log(header.name + std::string(" : ") + header.value);
+            if (header.name == "Host") {
+                int ret_val = beginConnectToServer(header.value, HTTP_PORT);
+                if (ret_val == status_code::FAIL) {
+                    logErrorWithErrno("Failed to connect to remote");
+                    return status_code::FAIL;
+                }
+                int sd = ret_val;
+                assert(servers->contains(sd));
+                servers->at(sd).message_queue.push_back(request_message);
+                Resource *resource;
+                if (!cache->contains(res_name)) {
+                    resource = new SimpleResource();
+                    cache->put(res_name, resource);
+                } else {
+                    resource = cache->get(res_name);
+                }
+                if (resource == nullptr) {
+                    logError("Resource is null");
+                    return status_code::FAIL;
+                }
+                int res_fd = resource->getNotifyFd();
+                selected->addFd(res_fd, io::SelectData::READ);
+                (*resource_names)[res_fd] = res_name;
+                if (servers->contains(sd)) {
+                    log("Server res name : " + servers->at(sd).res_name);
+                }
+                clients->at(client_fd).res_name = res_name;
+                servers->at(sd).res_name = res_name;
+                log(std::string("Started connecting to " + header.value));
+                return ret_val;
+            }
+        }
+        logError("Not found host header");
+        return status_code::FAIL;
+    }
+
+    int ProxyWorker::notifySubscribers(Resource *resource) {
+        size_t post_count = resource->getSubscribesCount();
+        if (post_count == 0) post_count = 1;
+        int code = eventfd_write(resource->getNotifyFd(), post_count);
+        if (code == 0) {
+            log("Sent notification to " + std::to_string(post_count) + " clients");
+        }
+        return code;
+    }
+
+    int ProxyWorker::readServerResponse(int server_fd, io::Message *new_part) {
+        auto res_name = servers->at(server_fd).res_name;
+        if (!cache->contains(res_name)) {
+            logError("Response with out name in cache");
+            cache->put(res_name, new SimpleResource);
+        }
+//        log("Received " + std::to_string(new_part->len) + " bytes");
+        auto resource = cache->get(res_name);
+        resource->getParts()->add(new_part);
+        io::Message *full_msg = new_part;
+        if (resource->getContentLength() == 0) {
+            if (resource->getData() != nullptr) {
+                full_msg = resource->getData();
+                bool added = io::AppendMsg(resource->getData(), new_part);
+                if (!added) {
+                    return status_code::FAIL;
+                }
+            } else {
+                resource->updateData(io::copy(new_part));
+            }
+        }
+        resource->setCurrentLength(resource->getCurrentLength() + new_part->len);
+//        log("Server " + std::to_string(fd) + " received " + std::to_string(resource->getCurrentLength()) +
+//            "/" + std::to_string(resource->getContentLength()) + " bytes");
+        if (resource->getContentLength() > resource->getCurrentLength()) {
+            return notifySubscribers(resource);
+        } else if (resource->getContentLength() == resource->getCurrentLength()
+                   && resource->getCurrentLength() > 0) {
+            resource->setStatus(COMPLETED);
+            delete resource->getData();
+            resource->updateData(nullptr);
+            notifySubscribers(resource);
+            return status_code::SUCCESS;
+        }
+        httpparser::Response response;
+        httpparser::HttpResponseParser parser;
+        httpparser::HttpResponseParser::ParseResult res = parser.parse(response, full_msg->data,
+                                                                       full_msg->data + full_msg->len);
+        log("Parsed response");
+        if (res == httpparser::HttpResponseParser::ParsingError) {
+            logError("Failed to parse response of " + res_name);
+            return status_code::FAIL;
+        }
+        notifySubscribers(resource);
+        if (res == httpparser::HttpResponseParser::ParsingIncompleted) {
+            auto content_length_header = std::find_if(response.headers.begin(), response.headers.end(),
+                                                      [&](const httpparser::Response::HeaderItem &item) {
+                                                          return item.name == "Content-Length";
+                                                      });
+            if (content_length_header != response.headers.end()) {
+                size_t content_length = std::stoul(content_length_header->value);
+                resource->setContentLength(content_length);
+                assert(full_msg->len > response.content.size());
+                size_t sub = full_msg->len - response.content.size();
+                if (sub > 0) {
+                    resource->setContentLength(content_length + sub);
+                }
+                log("Content-Length : " + std::to_string(resource->getContentLength()));
+            }
+            log("Response of is not complete, it's current length: " +
+                std::to_string(full_msg->len));
+            assert(resource->getStatus() == INCOMPLETED);
+            return status_code::SUCCESS;
+        }
+        log("Parsed response of " + res_name + std::string(" code: ") + std::to_string(response.statusCode));
+        resource->setStatus(COMPLETED);
+        log("Full bytes length : " + std::to_string(resource->getData()->len));
+        log("Full parts count : " + std::to_string(resource->getParts()->size()));
+        delete resource->getData();
+        resource->updateData(nullptr);
+        if (response.statusCode != 200) {
+            log("Status code is not 200, not store " + res_name + " in cache");
+        }
+        return status_code::SUCCESS;
+    }
+
+    int ProxyWorker::getNoticeFd() const {
+        return notice_fd;
+    }
+}

--- a/a.ivanov/33/src/proxy_worker/proxy_worker.h
+++ b/a.ivanov/33/src/proxy_worker/proxy_worker.h
@@ -23,13 +23,13 @@ namespace worker_thread_proxy {
     class ProxyWorker final : public Runnable {
     public:
 
-        ProxyWorker(int notice_fd, int signal_fd, aiwannafly::Cache<ResourceInfo> *cache);
+        ProxyWorker(int signal_fd, aiwannafly::Cache<ResourceInfo> *cache);
 
         ~ProxyWorker() override;
 
         int run() override;
 
-        [[nodiscard]] int getNoticeFd() const;
+        [[nodiscard]] io::SelectData *getSelected() const;
 
     private:
 
@@ -38,6 +38,8 @@ namespace worker_thread_proxy {
         int readClientRequest(int client_fd, io::Message *request_message);
 
         int readServerResponse(int server_fd, io::Message *new_part);
+
+        void updateClientQueue(int fd, bool reset);
 
         int writeMessageTo(int fd);
 
@@ -51,7 +53,6 @@ namespace worker_thread_proxy {
 
         void freeResources();
 
-        int notice_fd = -1;
         int signal_fd = -1;
         io::SelectData *selected;
         std::map<int, ClientInfo> *clients;

--- a/a.ivanov/33/src/proxy_worker/proxy_worker.h
+++ b/a.ivanov/33/src/proxy_worker/proxy_worker.h
@@ -11,36 +11,19 @@
 #include "../utils/select_data.h"
 #include "../utils/io_operations.h"
 #include "../cache/map_cache.h"
-#include "../resource/resource.h"
+#include "../resource/resource_info.h"
 #include "../runnable.h"
+#include "peers.h"
 
 #include "../../httpparser/src/httpparser/httpresponseparser.h"
 #include "../../httpparser/src/httpparser/response.h"
 
 namespace worker_thread_proxy {
 
-    typedef struct ServerInfo {
-        std::vector<io::Message *> message_queue = std::vector<io::Message *>();
-        bool connected = false;
-        std::string res_name;
-
-        ServerInfo() = default;
-        ~ServerInfo() = default;
-    } ServerInfo;
-
-    typedef struct ClientInfo {
-        std::vector<io::Message *> message_queue = std::vector<io::Message *>();
-        std::string res_name;
-        size_t recv_msg_count = 0;
-
-        ClientInfo() = default;
-        ~ClientInfo() = default;
-    } ClientInfo;
-
     class ProxyWorker final : public Runnable {
     public:
 
-        ProxyWorker(int notice_fd, int signal_fd, aiwannafly::Cache<Resource> *cache);
+        ProxyWorker(int notice_fd, int signal_fd, aiwannafly::Cache<ResourceInfo> *cache);
 
         ~ProxyWorker() override;
 
@@ -52,8 +35,6 @@ namespace worker_thread_proxy {
 
         int readMessageFrom(int fd);
 
-        int readResourceNotification(int notice_fd);
-
         int readClientRequest(int client_fd, io::Message *request_message);
 
         int readServerResponse(int server_fd, io::Message *new_part);
@@ -64,7 +45,7 @@ namespace worker_thread_proxy {
 
         int finishConnectToServer(int fd);
 
-        static int notifySubscribers(Resource *resource);
+        static void notifySubscribers(const std::string &res_name, ResourceInfo *resource) ;
 
         int closeConnection(int fd);
 
@@ -75,9 +56,7 @@ namespace worker_thread_proxy {
         io::SelectData *selected;
         std::map<int, ClientInfo> *clients;
         std::map<int, ServerInfo> *servers;
-        std::map<int, std::string> *resource_names;
-
-        aiwannafly::Cache<Resource> *cache;
+        aiwannafly::Cache<ResourceInfo> *cache;
         std::map<std::string, struct hostent *> *DNS_map;
     };
 }

--- a/a.ivanov/33/src/proxy_worker/proxy_worker.h
+++ b/a.ivanov/33/src/proxy_worker/proxy_worker.h
@@ -23,7 +23,7 @@ namespace worker_thread_proxy {
     class ProxyWorker final : public Runnable {
     public:
 
-        ProxyWorker(int signal_fd, aiwannafly::Cache<ResourceInfo> *cache);
+        ProxyWorker(int signal_fd, Cache<ResourceInfo> *cache);
 
         ~ProxyWorker() override;
 
@@ -39,7 +39,7 @@ namespace worker_thread_proxy {
 
         int readServerResponse(int server_fd, io::Message *new_part);
 
-        void updateClientQueue(int fd, bool reset);
+        void lootNewResourceParts(int fd, bool reset);
 
         int writeMessageTo(int fd);
 
@@ -55,9 +55,9 @@ namespace worker_thread_proxy {
 
         int signal_fd = -1;
         io::SelectData *selected;
-        std::map<int, ClientInfo> *clients;
-        std::map<int, ServerInfo> *servers;
-        aiwannafly::Cache<ResourceInfo> *cache;
+        std::map<int, ClientInfo*> *clients;
+        std::map<int, ServerInfo*> *servers;
+        Cache<ResourceInfo> *cache;
         std::map<std::string, struct hostent *> *DNS_map;
     };
 }

--- a/a.ivanov/33/src/proxy_worker/proxy_worker.h
+++ b/a.ivanov/33/src/proxy_worker/proxy_worker.h
@@ -1,0 +1,85 @@
+#ifndef HTTP_CPP_PROXY_SINGLE_THREAD_PROXY_H
+#define HTTP_CPP_PROXY_SINGLE_THREAD_PROXY_H
+
+#include <cstdlib>
+#include <map>
+#include <set>
+#include <vector>
+#include <netdb.h>
+
+#include "../proxy.h"
+#include "../utils/select_data.h"
+#include "../utils/io_operations.h"
+#include "../cache/map_cache.h"
+#include "../resource/resource.h"
+#include "../runnable.h"
+
+#include "../../httpparser/src/httpparser/httpresponseparser.h"
+#include "../../httpparser/src/httpparser/response.h"
+
+namespace worker_thread_proxy {
+
+    typedef struct ServerInfo {
+        std::vector<io::Message *> message_queue = std::vector<io::Message *>();
+        bool connected = false;
+        std::string res_name;
+
+        ServerInfo() = default;
+        ~ServerInfo() = default;
+    } ServerInfo;
+
+    typedef struct ClientInfo {
+        std::vector<io::Message *> message_queue = std::vector<io::Message *>();
+        std::string res_name;
+        size_t recv_msg_count = 0;
+
+        ClientInfo() = default;
+        ~ClientInfo() = default;
+    } ClientInfo;
+
+    class ProxyWorker final : public Runnable {
+    public:
+
+        ProxyWorker(int notice_fd, int signal_fd, aiwannafly::Cache<Resource> *cache);
+
+        ~ProxyWorker() override;
+
+        int run() override;
+
+        [[nodiscard]] int getNoticeFd() const;
+
+    private:
+
+        int readMessageFrom(int fd);
+
+        int readResourceNotification(int notice_fd);
+
+        int readClientRequest(int client_fd, io::Message *request_message);
+
+        int readServerResponse(int server_fd, io::Message *new_part);
+
+        int writeMessageTo(int fd);
+
+        int beginConnectToServer(const std::string &hostname, int port);
+
+        int finishConnectToServer(int fd);
+
+        static int notifySubscribers(Resource *resource);
+
+        int closeConnection(int fd);
+
+        void freeResources();
+
+        int notice_fd = -1;
+        int signal_fd = -1;
+        io::SelectData *selected;
+        std::map<int, ClientInfo> *clients;
+        std::map<int, ServerInfo> *servers;
+        std::map<int, std::string> *resource_names;
+
+        aiwannafly::Cache<Resource> *cache;
+        std::map<std::string, struct hostent *> *DNS_map;
+    };
+}
+
+#endif //HTTP_CPP_PROXY_SINGLE_THREAD_PROXY_H

--- a/a.ivanov/33/src/resource/resource.h
+++ b/a.ivanov/33/src/resource/resource.h
@@ -1,0 +1,45 @@
+#ifndef PTHREAD_HTTP_PROXY_RESOURCE_H
+#define PTHREAD_HTTP_PROXY_RESOURCE_H
+
+
+#include "../sync/list.h"
+#include "../utils/io_operations.h"
+
+namespace worker_thread_proxy {
+    enum ResourceStatus {
+        BAD, INCOMPLETED, COMPLETED
+    };
+
+    class Resource {
+    public:
+        virtual ~Resource() = default;
+
+        virtual int getNotifyFd() = 0;
+
+        virtual int subscribe() = 0;
+
+        virtual int cancel() = 0;
+
+        virtual size_t getSubscribesCount() = 0;
+
+        virtual io::Message *getData() = 0;
+
+        virtual void updateData(io::Message *data) = 0;
+
+        virtual List<io::Message> *getParts() = 0;
+
+        virtual void setStatus(ResourceStatus r) = 0;
+
+        virtual ResourceStatus getStatus() = 0;
+
+        virtual void setContentLength(size_t content_length) = 0;
+
+        virtual size_t getContentLength() = 0;
+
+        virtual void setCurrentLength(size_t current_length) = 0;
+
+        virtual size_t getCurrentLength() = 0;
+    };
+}
+
+#endif //PTHREAD_HTTP_PROXY_RESOURCE_H

--- a/a.ivanov/33/src/resource/resource_info.h
+++ b/a.ivanov/33/src/resource/resource_info.h
@@ -23,6 +23,7 @@ namespace worker_thread_proxy {
         size_t content_length = 0;
         bool free_messages = true;
         bool has_content_length = false;
+        int server_fd = -1;
         // vector of socket descriptors of clients who wait for the resource
 
         ResourceInfo() = default;

--- a/a.ivanov/33/src/resource/resource_info.h
+++ b/a.ivanov/33/src/resource/resource_info.h
@@ -2,9 +2,9 @@
 #define PTHREAD_HTTP_PROXY_SIMPLE_RESOURCE_H
 
 #include <cassert>
-#include <set>
 #include <vector>
 
+#include "resource_subscriber.h"
 #include "../sync/threadsafe_list.h"
 #include "../utils/io_operations.h"
 #include "../utils/select_data.h"
@@ -13,48 +13,19 @@
 
 namespace worker_thread_proxy {
 
-    typedef struct Subscriber {
-        io::SelectData *selected;
-        int fd;
-        ClientInfo *client;
-
-        Subscriber(io::SelectData *selected, int fd, ClientInfo *client) {
-            assert(selected);
-            assert(client);
-            this->selected = selected;
-            this->fd = fd;
-            this->client = client;
-        }
-
-        bool operator<(const Subscriber& sub2) const {
-            return fd < sub2.fd;
-            //Return true if this is less than loc2
-        }
-    } Subscriber;
-
     typedef struct ResourceInfo {
     public:
         httpparser::HttpResponseParser::ParseResult status = httpparser::HttpResponseParser::ParsingIncompleted;
-        ThreadsafeList<io::Message> parts = ThreadsafeList<io::Message>();
+        ThreadsafeList<io::Message*> parts = ThreadsafeList<io::Message*>();
+        ThreadsafeList<Subscriber> subscribers = ThreadsafeList<Subscriber>();
         io::Message *full_data = nullptr;
         size_t cur_length = 0;
         size_t content_length = 0;
         bool free_messages = true;
+        bool has_content_length = false;
         // vector of socket descriptors of clients who wait for the resource
-        std::set<Subscriber> subscribers = std::set<Subscriber>();
 
-        ResourceInfo() {
-            mutex = new pthread_mutex_t;
-            pthread_mutex_init(mutex, nullptr);
-        }
-
-        void lock() {
-            pthread_mutex_lock(mutex);
-        }
-
-        void unlock() {
-            pthread_mutex_unlock(mutex);
-        }
+        ResourceInfo() = default;
 
         ~ResourceInfo() {
             delete full_data;
@@ -63,12 +34,8 @@ namespace worker_thread_proxy {
                     delete part;
                 }
             }
-            pthread_mutex_destroy(mutex);
-            delete mutex;
         }
 
-    private:
-        pthread_mutex_t *mutex;
     } ResourceInfo;
 }
 

--- a/a.ivanov/33/src/resource/resource_info.h
+++ b/a.ivanov/33/src/resource/resource_info.h
@@ -5,6 +5,7 @@
 #include <set>
 #include <vector>
 
+#include "../sync/threadsafe_list.h"
 #include "../utils/io_operations.h"
 #include "../utils/select_data.h"
 #include "../../httpparser/src/httpparser/httpresponseparser.h"
@@ -33,7 +34,7 @@ namespace worker_thread_proxy {
 
     typedef struct ResourceInfo {
         httpparser::HttpResponseParser::ParseResult status = httpparser::HttpResponseParser::ParsingIncompleted;
-        std::vector<io::Message *> parts = std::vector<io::Message *>();
+        ThreadsafeList<io::Message> parts = ThreadsafeList<io::Message>();
         io::Message *full_data = nullptr;
         size_t current_length = 0;
         size_t content_length = 0;
@@ -46,8 +47,8 @@ namespace worker_thread_proxy {
         ~ResourceInfo() {
             delete full_data;
             if (free_messages) {
-                for (auto msg: parts) {
-                    delete msg;
+                for (auto part : parts) {
+                    delete part;
                 }
             }
         }

--- a/a.ivanov/33/src/resource/resource_info.h
+++ b/a.ivanov/33/src/resource/resource_info.h
@@ -37,7 +37,7 @@ namespace worker_thread_proxy {
         httpparser::HttpResponseParser::ParseResult status = httpparser::HttpResponseParser::ParsingIncompleted;
         ThreadsafeList<io::Message> parts = ThreadsafeList<io::Message>();
         io::Message *full_data = nullptr;
-        size_t current_length = 0;
+        size_t cur_length = 0;
         size_t content_length = 0;
         bool free_messages = true;
         // vector of socket descriptors of clients who wait for the resource

--- a/a.ivanov/33/src/resource/resource_info.h
+++ b/a.ivanov/33/src/resource/resource_info.h
@@ -1,0 +1,57 @@
+#ifndef PTHREAD_HTTP_PROXY_SIMPLE_RESOURCE_H
+#define PTHREAD_HTTP_PROXY_SIMPLE_RESOURCE_H
+
+#include <cassert>
+#include <set>
+#include <vector>
+
+#include "../utils/io_operations.h"
+#include "../utils/select_data.h"
+#include "../../httpparser/src/httpparser/httpresponseparser.h"
+#include "../proxy_worker/peers.h"
+
+namespace worker_thread_proxy {
+
+    typedef struct Subscriber {
+        io::SelectData *selected;
+        int fd;
+        ClientInfo *client;
+
+        Subscriber(io::SelectData *selected, int fd, ClientInfo *client) {
+            assert(selected);
+            assert(client);
+            this->selected = selected;
+            this->fd = fd;
+            this->client = client;
+        }
+
+        bool operator<(const Subscriber& sub2) const {
+            return fd < sub2.fd;
+            //Return true if this is less than loc2
+        }
+    } Subscriber;
+
+    typedef struct ResourceInfo {
+        httpparser::HttpResponseParser::ParseResult status = httpparser::HttpResponseParser::ParsingIncompleted;
+        std::vector<io::Message *> parts = std::vector<io::Message *>();
+        io::Message *full_data = nullptr;
+        size_t current_length = 0;
+        size_t content_length = 0;
+        bool free_messages = true;
+        // vector of socket descriptors of clients who wait for the resource
+        std::set<Subscriber> subscribers = std::set<Subscriber>();
+
+        ResourceInfo() = default;
+
+        ~ResourceInfo() {
+            delete full_data;
+            if (free_messages) {
+                for (auto msg: parts) {
+                    delete msg;
+                }
+            }
+        }
+    } ResourceInfo;
+}
+
+#endif //PTHREAD_HTTP_PROXY_SIMPLE_RESOURCE_H

--- a/a.ivanov/33/src/resource/resource_subscriber.h
+++ b/a.ivanov/33/src/resource/resource_subscriber.h
@@ -1,0 +1,25 @@
+#ifndef WORKER_THREADS_PROXY_RESOURCE_SUBSCRIBER_H
+#define WORKER_THREADS_PROXY_RESOURCE_SUBSCRIBER_H
+
+#include "../utils/select_data.h"
+#include "../proxy_worker/peers.h"
+
+namespace worker_thread_proxy {
+    typedef struct Subscriber {
+        io::SelectData *selected;
+        int fd;
+
+        Subscriber(io::SelectData *selected, int fd) {
+            assert(selected);
+            this->selected = selected;
+            this->fd = fd;
+        }
+
+        bool operator<(const Subscriber& sub2) const {
+            return fd < sub2.fd;
+            //Return true if this is less than loc2
+        }
+    } Subscriber;
+}
+
+#endif //WORKER_THREADS_PROXY_RESOURCE_SUBSCRIBER_H

--- a/a.ivanov/33/src/resource/simple_resource.h
+++ b/a.ivanov/33/src/resource/simple_resource.h
@@ -1,0 +1,118 @@
+#ifndef PTHREAD_HTTP_PROXY_SIMPLE_RESOURCE_H
+#define PTHREAD_HTTP_PROXY_SIMPLE_RESOURCE_H
+
+#include <cassert>
+#include <set>
+#include <vector>
+#include <unistd.h>
+#include <sys/eventfd.h>
+
+#include "resource.h"
+
+#include "../utils/io_operations.h"
+#include "../utils/log.h"
+#include "../sync/threadsafe_list.h"
+
+namespace worker_thread_proxy {
+
+    class SimpleResource : public Resource {
+    public:
+        SimpleResource() {
+            event_fd = eventfd(0, EFD_SEMAPHORE);
+            if (event_fd == -1) {
+                logErrorWithErrno("Error in eventfd()");
+                assert(false);
+            }
+            rwlock = new pthread_rwlock_t;
+            int code = pthread_rwlock_init(rwlock, nullptr);
+            assert(code >= 0);
+            parts = new ThreadsafeList<io::Message>(rwlock);
+        }
+
+        ~SimpleResource() override {
+            delete full_data;
+            if (free_messages) {
+                size_t size = parts->size();
+                for (size_t i = 0; i < size; i++) {
+                    delete parts->at(i);
+                }
+            }
+            delete parts;
+            pthread_rwlock_destroy(rwlock);
+            delete rwlock;
+        }
+
+        int getNotifyFd() override {
+            return event_fd;
+        }
+
+        int subscribe() override {
+            pthread_rwlock_wrlock(rwlock);
+            subscribes_count++;
+            pthread_rwlock_unlock(rwlock);
+            return event_fd;
+        }
+
+        int cancel() override {
+            pthread_rwlock_wrlock(rwlock);
+            if (subscribes_count > 0) subscribes_count--;
+            pthread_rwlock_unlock(rwlock);
+            return event_fd;
+        }
+
+        size_t getSubscribesCount() override {
+            return subscribes_count;
+        }
+
+        List<io::Message> *getParts() override {
+            return parts;
+        }
+
+        void setStatus(ResourceStatus r) override {
+            status = r;
+        }
+
+        ResourceStatus getStatus() override {
+            return status;
+        }
+
+        void setContentLength(size_t new_content_length) override {
+            this->content_length = new_content_length;
+        }
+
+        size_t getContentLength() override {
+            return content_length;
+        }
+
+        void setCurrentLength(size_t new_current_length) override {
+            this->current_length = new_current_length;
+        }
+
+        size_t getCurrentLength() override {
+            return current_length;
+        }
+
+        io::Message *getData() override {
+            return full_data;
+        }
+
+        void updateData(io::Message *data) override {
+            full_data = data;
+        }
+
+    private:
+        int event_fd;
+        ResourceStatus status = INCOMPLETED;
+        List<io::Message> *parts;
+        io::Message *full_data = nullptr;
+        size_t current_length = 0;
+        size_t content_length = 0;
+        bool free_messages = true;
+        pthread_rwlock_t *rwlock;
+
+        size_t subscribes_count = 0;
+        // vector of socket descriptors of clients who wait for the resource
+    };
+}
+
+#endif //PTHREAD_HTTP_PROXY_SIMPLE_RESOURCE_H

--- a/a.ivanov/33/src/runnable.h
+++ b/a.ivanov/33/src/runnable.h
@@ -1,0 +1,13 @@
+#ifndef PTHREAD_HTTP_PROXY_RUNNABLE_H
+#define PTHREAD_HTTP_PROXY_RUNNABLE_H
+
+class Runnable {
+public:
+
+    virtual ~Runnable() = default;
+
+    virtual int run() = 0;
+
+};
+
+#endif //PTHREAD_HTTP_PROXY_RUNNABLE_H

--- a/a.ivanov/33/src/status_code.h
+++ b/a.ivanov/33/src/status_code.h
@@ -1,0 +1,11 @@
+#ifndef HTTP_CPP_PROXY_STATUS_CODE_H
+#define HTTP_CPP_PROXY_STATUS_CODE_H
+
+namespace status_code {
+    static const int FAIL = -1;
+    static const int SUCCESS = 0;
+    static const int TIMEOUT = 0;
+    static const int TERMINATE  = -2;
+}
+
+#endif //HTTP_CPP_PROXY_STATUS_CODE_H

--- a/a.ivanov/33/src/sync/list.h
+++ b/a.ivanov/33/src/sync/list.h
@@ -1,0 +1,18 @@
+#ifndef PTHREAD_HTTP_PROXY_LIST_H
+#define PTHREAD_HTTP_PROXY_LIST_H
+
+#include <cstddef>
+
+template <class T>
+class List {
+public:
+    virtual ~List() = default;
+
+    virtual void add(T *) = 0;
+
+    virtual size_t size() const = 0;
+
+    virtual T* at(size_t) const = 0;
+};
+
+#endif //PTHREAD_HTTP_PROXY_LIST_H

--- a/a.ivanov/33/src/sync/threadsafe_list.h
+++ b/a.ivanov/33/src/sync/threadsafe_list.h
@@ -1,0 +1,47 @@
+#ifndef PTHREAD_HTTP_PROXY_THREADSAFE_LIST_H
+#define PTHREAD_HTTP_PROXY_THREADSAFE_LIST_H
+
+#include <cassert>
+#include <cstddef>
+#include <vector>
+#include "pthread.h"
+
+#include "list.h"
+
+template <class T>
+class ThreadsafeList : public List<T>{
+public:
+    explicit ThreadsafeList(pthread_rwlock_t *rwlock) {
+        list = std::vector<T*>();
+        this->rwlock = rwlock;
+    }
+
+    ~ThreadsafeList() override = default;
+
+    T *at(size_t pos) const override {
+        pthread_rwlock_rdlock(rwlock);
+        auto res = list.at(pos);
+        pthread_rwlock_unlock(rwlock);
+        return res;
+    }
+
+    size_t size() const override {
+        pthread_rwlock_rdlock(rwlock);
+        auto res = list.size();
+        pthread_rwlock_unlock(rwlock);
+        return res;
+    }
+
+    void add(T *new_elem) override {
+        pthread_rwlock_wrlock(rwlock);
+        list.push_back(new_elem);
+        pthread_rwlock_unlock(rwlock);
+    }
+
+private:
+    std::vector<T*> list;
+    pthread_rwlock_t *rwlock{};
+};
+
+
+#endif //PTHREAD_HTTP_PROXY_THREADSAFE_LIST_H

--- a/a.ivanov/33/src/sync/threadsafe_list.h
+++ b/a.ivanov/33/src/sync/threadsafe_list.h
@@ -4,15 +4,13 @@
 #include <cassert>
 #include <cstddef>
 #include <vector>
-#include "pthread.h"
-
-#include "list.h"
+#include <pthread.h>
 
 template <class T>
 class ThreadsafeList {
 public:
     explicit ThreadsafeList() {
-        vec = std::vector<T*>();
+        vec = std::vector<T>();
         rwlock = new pthread_rwlock_t;
         int code = pthread_rwlock_init(rwlock, nullptr);
         assert(code == 0);
@@ -23,27 +21,27 @@ public:
         delete rwlock;
     };
 
-    void push_back(T* in) {
+    void push_back(const T &in) {
         pthread_rwlock_wrlock(rwlock);
         vec.push_back(in);
         pthread_rwlock_unlock(rwlock);
     }
 
-    T* operator[](const int index) {
+    T &operator[](const int index) {
         pthread_rwlock_rdlock(rwlock);
         auto res = vec[index];
         pthread_rwlock_unlock(rwlock);
         return res;
     }
 
-    T* at(const int index) {
+    T &at(const int index) {
         pthread_rwlock_rdlock(rwlock);
         auto res = vec[index];
         pthread_rwlock_unlock(rwlock);
         return res;
     }
 
-    T* front() {
+    T &front() {
         pthread_rwlock_rdlock(rwlock);
         auto res = vec.front();
         pthread_rwlock_unlock(rwlock);
@@ -64,7 +62,7 @@ public:
         return res;
     }
 
-    void erase(typename std::vector<T*>::iterator index) {
+    void erase(typename std::vector<T>::iterator index) {
         pthread_rwlock_wrlock(rwlock);
         vec.erase(index);
         pthread_rwlock_unlock(rwlock);
@@ -76,14 +74,14 @@ public:
         pthread_rwlock_unlock(rwlock);
     }
 
-    typename std::vector<T*>::iterator begin(){
+    typename std::vector<T>::iterator begin(){
         pthread_rwlock_rdlock(rwlock);
         auto res = vec.begin();
         pthread_rwlock_unlock(rwlock);
         return res;
     }
 
-    typename std::vector<T*>::iterator end() {
+    typename std::vector<T>::iterator end() {
         pthread_rwlock_rdlock(rwlock);
         auto res = vec.end();
         pthread_rwlock_unlock(rwlock);
@@ -91,7 +89,7 @@ public:
     }
 
 private:
-    std::vector<T*> vec;
+    std::vector<T> vec;
     pthread_rwlock_t *rwlock{};
 };
 

--- a/a.ivanov/33/src/utils/io_operations.cpp
+++ b/a.ivanov/33/src/utils/io_operations.cpp
@@ -1,0 +1,202 @@
+#include "io_operations.h"
+
+#include <cassert>
+#include <cerrno>
+#include <cstdlib>
+#include <cstdio>
+#include <unistd.h>
+#include <cstring>
+
+#include "../status_code.h"
+
+namespace io {
+    static const int DEFAULT_BUFFER_SIZE = 128;
+
+    Message *copy(Message *prev) {
+        assert(prev);
+        auto *res = new Message;
+        res->len = prev->len;
+        res->capacity = prev->capacity;
+        res->data = (char *) malloc(res->capacity);
+        memcpy((void *) res->data, prev->data, res->len);
+        return res;
+    }
+
+    bool AppendMsg(Message *a, Message *b) {
+        assert(a);
+        assert(b);
+        size_t required_length = a->len + b->len + 1;
+        while (a->capacity < required_length) {
+            a->capacity *= 2;
+            char *temp = (char *) realloc((void *) a->data, a->capacity);
+            if (temp == nullptr) {
+                return false;
+            }
+            a->data = temp;
+        }
+        memcpy((void *) (a->data + a->len), b->data, b->len);
+        a->len += b->len;
+        return true;
+    }
+
+    bool WriteAll(int fd, Message *message) {
+        if (nullptr == message) {
+            return false;
+        }
+        if (nullptr == message->data) {
+            return false;
+        }
+        size_t written_bytes = 0;
+        size_t left_to_write = message->len;
+        while (true) {
+            ssize_t count = write(fd, message->data + written_bytes, left_to_write);
+            if (count == status_code::FAIL) {
+                return false;
+            }
+            written_bytes += count;
+            if (written_bytes == message->len) {
+                return true;
+            }
+            left_to_write -= count;
+        }
+    }
+
+    bool fwrite_into_pipe(FILE *pipe_fd, char *buffer, size_t len) {
+        if (nullptr == buffer || nullptr == pipe_fd) {
+            return false;
+        }
+        size_t written_bytes = 0;
+        size_t left_to_write = len;
+        while (true) {
+            size_t count = fwrite(buffer + written_bytes, sizeof(char),  left_to_write, pipe_fd);
+            if (ferror(pipe_fd)) {
+                return false;
+            }
+            written_bytes += count;
+            if (written_bytes == len) {
+                return true;
+            }
+            left_to_write -= count;
+        }
+    }
+
+    Message *read_all(int socket_fd) {
+        size_t capacity = DEFAULT_BUFFER_SIZE;
+        char *buffer = (char *) malloc(capacity + 1);
+        if (buffer == nullptr) {
+            return nullptr;
+        }
+        size_t offset = 0;
+        size_t portion = DEFAULT_BUFFER_SIZE;
+        while (true) {
+            if (offset + portion > capacity) {
+                capacity *= 2;
+                char *temp = (char *) realloc(buffer, capacity);
+                if (nullptr == temp) {
+                    free(buffer);
+                    return nullptr;
+                }
+                buffer = temp;
+            }
+            long read_bytes = read(socket_fd, buffer + offset, portion);
+            if (status_code::FAIL == read_bytes) {
+                if (errno == EINTR) {
+                    continue;
+                } else if (errno == EAGAIN) {
+                    buffer[offset] = '\0';
+                    auto *message = new Message;
+                    message->data = buffer;
+                    message->len = offset;
+                    message->capacity = capacity;
+                    return message;
+                } else {
+                    free(buffer);
+                    return nullptr;
+                }
+            }
+            if (0 == read_bytes || offset >= MSG_LENGTH_LIMIT) {
+                offset += read_bytes;
+                break;
+            } else {
+                offset += read_bytes;
+                if (offset % portion != 0) {
+                    break;
+                }
+            }
+        }
+        buffer[offset] = '\0';
+        auto *message = new Message;
+        message->data = buffer;
+        message->len = offset;
+        message->capacity = capacity;
+        return message;
+    }
+
+    char *read_from_file(int pipe_fd) {
+        size_t capacity = DEFAULT_BUFFER_SIZE;
+        char *buffer = (char *) malloc(capacity);
+        size_t offset = 0;
+        size_t portion = DEFAULT_BUFFER_SIZE;
+        while (true) {
+            printf("offset: %zu\n", offset);
+            if (offset + portion > capacity) {
+                capacity *= 2;
+                char *temp = (char *) realloc(buffer, capacity);
+                if (nullptr == temp) {
+                    free(buffer);
+                    return nullptr;
+                }
+                buffer = temp;
+            }
+            if (buffer[offset] == 0) {
+                break;
+            }
+            long read_bytes = read(pipe_fd, buffer + offset, portion);
+            if (status_code::FAIL == read_bytes) {
+                if (errno == EINTR) {
+                    continue;
+                } else {
+                    free(buffer);
+                    return nullptr;
+                }
+            }
+            if (0 == read_bytes) {
+                break;
+            } else {
+                offset += read_bytes;
+            }
+        }
+        buffer[offset] = '\0';
+        return buffer;
+    }
+
+    char *fread_from_pipe(FILE *pipe_fp) {
+        size_t capacity = DEFAULT_BUFFER_SIZE;
+        char *buffer = (char *) malloc(capacity);
+        size_t offset = 0;
+        size_t portion = DEFAULT_BUFFER_SIZE;
+        while (true) {
+            if (offset + portion > capacity) {
+                capacity *= 2;
+                char *temp = (char *) realloc(buffer, capacity);
+                if (nullptr == temp) {
+                    free(buffer);
+                    return nullptr;
+                }
+                buffer = temp;
+            }
+            unsigned long read_bytes = fread(buffer + offset, sizeof(char), portion, pipe_fp);
+            if (ferror(pipe_fp)) {
+                free(buffer);
+                return nullptr;
+            }
+            if (0 == read_bytes) {
+                break;
+            } else {
+                offset += read_bytes;
+            }
+        }
+        buffer[offset] = '\0';
+        return buffer;
+    }
+}

--- a/a.ivanov/33/src/utils/io_operations.h
+++ b/a.ivanov/33/src/utils/io_operations.h
@@ -1,0 +1,36 @@
+#ifndef HTTP_CPP_PROXY_IO_OPERATIONS_H
+#define HTTP_CPP_PROXY_IO_OPERATIONS_H
+
+#include <cstdlib>
+#include <cstdio>
+#include <string>
+
+namespace io {
+    static const int READ_PIPE_END = 0;
+    static const int WRITE_PIPE_END = 1;
+    static const int MSG_LENGTH_LIMIT = 32 * 1024;
+
+    typedef struct Message {
+    public:
+        const char *data;
+        size_t len;
+        size_t capacity;
+
+        Message() = default;
+
+        ~Message() {
+            free((void *) data);
+        }
+
+    } Message;
+
+    Message *copy(Message *prev);
+
+    bool AppendMsg(Message *a, Message *b);
+
+    bool WriteAll(int fd, Message *message);
+
+    Message *read_all(int socket_fd);
+}
+
+#endif //HTTP_CPP_PROXY_IO_OPERATIONS_H

--- a/a.ivanov/33/src/utils/log.cpp
+++ b/a.ivanov/33/src/utils/log.cpp
@@ -1,0 +1,21 @@
+#include "log.h"
+
+#include <iostream>
+
+bool print_allowed = true;
+std::string prefix = "[PROXY ] ";
+
+void log(const std::string &msg) {
+    if (!print_allowed) return;
+    std::cout << prefix << msg << std::endl;
+}
+
+void logError(const std::string &msg) {
+    if (!print_allowed) return;
+    std::cerr << prefix << msg << std::endl;
+}
+
+void logErrorWithErrno(const std::string &msg) {
+    if (!print_allowed) return;
+    perror((prefix + msg).data());
+}

--- a/a.ivanov/33/src/utils/log.h
+++ b/a.ivanov/33/src/utils/log.h
@@ -1,0 +1,12 @@
+#ifndef PTHREAD_HTTP_PROXY_LOG_H
+#define PTHREAD_HTTP_PROXY_LOG_H
+
+#include <string>
+
+void log(const std::string &msg);
+
+void logError(const std::string &msg);
+
+void logErrorWithErrno(const std::string &msg);
+
+#endif //PTHREAD_HTTP_PROXY_LOG_H

--- a/a.ivanov/33/src/utils/select_data.h
+++ b/a.ivanov/33/src/utils/select_data.h
@@ -1,0 +1,64 @@
+#ifndef HTTP_CPP_PROXY_SELECT_DATA_H
+#define HTTP_CPP_PROXY_SELECT_DATA_H
+
+#include <cstdlib>
+
+namespace io {
+    class SelectData {
+    public:
+        enum fd_type {
+            READ, WRITE
+        };
+
+        SelectData() {
+            FD_ZERO(read_set);
+            FD_ZERO(write_set);
+        }
+
+        ~SelectData() {
+            delete read_set;
+            delete write_set;
+        }
+
+        void addFd(int fd, fd_type type) {
+            if (type == READ) {
+                FD_SET(fd, read_set);
+            } else {
+                FD_SET(fd, write_set);
+            }
+            if (fd > max_fd) {
+                max_fd = fd;
+            }
+        }
+
+        void remove_fd(int fd, fd_type type) {
+            if (type == READ) {
+                FD_CLR(fd, read_set);
+                if (fd == max_fd) {
+                    max_fd--;
+                }
+            } else {
+                FD_CLR(fd, write_set);
+            }
+        }
+
+        [[nodiscard]] fd_set *getReadSet() const {
+            return read_set;
+        }
+
+        [[nodiscard]] fd_set *getWriteSet() const {
+            return write_set;
+        }
+
+        [[nodiscard]] int getMaxFd() const {
+            return max_fd;
+        }
+
+    private:
+        int max_fd = 0;
+        fd_set *read_set = new fd_set;
+        fd_set *write_set = new fd_set;
+    };
+}
+
+#endif //HTTP_CPP_PROXY_SELECT_DATA_H

--- a/a.ivanov/33/src/utils/select_data.h
+++ b/a.ivanov/33/src/utils/select_data.h
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <cassert>
+#include <pthread.h>
 
 namespace io {
     class SelectData {

--- a/a.ivanov/33/src/utils/socket_operations.cpp
+++ b/a.ivanov/33/src/utils/socket_operations.cpp
@@ -1,0 +1,74 @@
+#include "socket_operations.h"
+
+#include "../status_code.h"
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+namespace socket_operations {
+    int SetNonblocking(int serv_socket) {
+        int option_value;
+        int return_value = ioctl(serv_socket, FIONBIO, (char *) &option_value); // Set socket to be nonblocking
+        if (return_value == status_code::FAIL) {
+            return status_code::FAIL;
+        }
+        return status_code::SUCCESS;
+    }
+
+    int SetReusable(int serv_socket) {
+        int option_value;
+        int return_value = setsockopt(serv_socket, SOL_SOCKET, SO_REUSEADDR, // Allow socket descriptor to be reusable
+                                      (char *) &option_value, sizeof(option_value));
+        if (return_value == status_code::FAIL) {
+            return status_code::FAIL;
+        }
+        return status_code::SUCCESS;
+    }
+
+    int ConnectToAddress(char *serv_ipv4_address, int port) {
+        if (port < 0 || port >= 65536) {
+            return status_code::FAIL;
+        }
+        int sd = socket(AF_INET, SOCK_STREAM, 0);
+        if (sd == status_code::FAIL) {
+            return status_code::FAIL;
+        }
+        struct sockaddr_in serv_sockaddr{};
+        serv_sockaddr.sin_family = AF_INET;
+        serv_sockaddr.sin_port = htons(port);
+        if (inet_pton(AF_INET, serv_ipv4_address, &serv_sockaddr.sin_addr) == status_code::FAIL) {
+            return status_code::FAIL;
+        }
+        int opt = fcntl(sd, F_GETFL, NULL);
+        if (opt < 0) {
+            return status_code::FAIL;
+        }
+        int return_code = fcntl(sd, F_SETFL, opt | O_NONBLOCK);
+        if (return_code < 0) {
+            return status_code::FAIL;
+        }
+        return_code = connect(sd, (const struct sockaddr *) &serv_sockaddr, sizeof(serv_sockaddr));
+        if (return_code == status_code::FAIL) {
+            return status_code::FAIL;
+        }
+        return sd;
+    }
+
+    int ConnectToSockaddr(struct sockaddr_in *addr, int port) {
+        int client_sd = socket(AF_INET, SOCK_STREAM, 0);
+        if (client_sd == status_code::FAIL) {
+            return status_code::FAIL;
+        }
+        struct sockaddr_in serv_sockaddr{};
+        serv_sockaddr.sin_family = AF_INET;
+        serv_sockaddr.sin_port = htons(port);
+        serv_sockaddr.sin_addr = addr->sin_addr;
+        int return_value = connect(client_sd, (struct sockaddr *) &serv_sockaddr, sizeof(serv_sockaddr));
+        if (return_value == status_code::FAIL) {
+            return status_code::FAIL;
+        }
+        return client_sd;
+    }
+
+}

--- a/a.ivanov/33/src/utils/socket_operations.h
+++ b/a.ivanov/33/src/utils/socket_operations.h
@@ -1,0 +1,17 @@
+#ifndef HTTP_CPP_PROXY_SOCKET_OPERATIONS_H
+#define HTTP_CPP_PROXY_SOCKET_OPERATIONS_H
+
+#include <arpa/inet.h>
+
+namespace socket_operations {
+
+    int SetNonblocking(int serv_socket);
+
+    int SetReusable(int serv_socket);
+
+    int ConnectToAddress(char *serv_ipv4_address, int port);
+
+    int ConnectToSockaddr(struct sockaddr_in *addr, int port);
+}
+
+#endif //HTTP_CPP_PROXY_SOCKET_OPERATIONS_H


### PR DESCRIPTION
Запуск выглядит так: `./prog <proxy_port> <worker_threads_count>`

Для парсинга HTTP сообщений в очередной раз использовал https://github.com/nekipelov/httpparser.

`main thread` отвечает за прием и распределение новых клиентских соединений и уведомление всех остальных потоков о преждевременном завершении посредством eventfd в режиме семафора.

Каждый `worker thread` имеет свой собственный селектор, очень похожий на тот, что был в задаче 31. `main thread` имеет прямой синхронизованный доступ ко всем этим селекторам, что позволяет ему легко и непринужденно распределять входящие клиентские соединения по воркерам.

В остальном же архитектура программы совпадает с архитектурой из задачи 31. Несколько изменился облик ресурса, теперь он использует `threadsafe` список для хранения кусков ресурса и подобный же список для хранения информации о подписках. По сути, подписка - это дескриптор клиентского соединения, жаждущего этот ресурс, вместе с селектором того `worker thread`, в котором этот дескриптор живёт.

При помощи тестирования было выявлено несколько интересных спецэффектов, таких как, например, создание сразу двух сессий скачивания одного и того же ресурса в кэш 😊, что решилось дополнительным мутексом вокруг кэша. На данный момент подобное поведение программы устранено, все тесты проходятся.